### PR TITLE
4835 improve error handling with guava

### DIFF
--- a/cli/src/main/java/montithings/steps/UnpackResources.java
+++ b/cli/src/main/java/montithings/steps/UnpackResources.java
@@ -1,6 +1,7 @@
 // (c) https://github.com/MontiCore/monticore
 package montithings.steps;
 
+import com.google.common.base.Verify;
 import montithings.CLIState;
 import montithings.CLIStep;
 import montithings.MTCLI;
@@ -54,7 +55,7 @@ public class UnpackResources extends CLIStep {
    * @param target copy destination directory
    */
   public void copyFromJar(String source, final Path target) throws URISyntaxException, IOException {
-    URI resource = Objects.requireNonNull(MTCLI.class.getResource("")).toURI();
+    URI resource = Verify.verifyNotNull(MTCLI.class.getResource("")).toURI();
     FileSystem fileSystem;
     try {
       fileSystem = FileSystems.newFileSystem(resource, Collections.<String, String>emptyMap());

--- a/generators/montithings2cpp/src/main/java/montithings/generator/helper/ComponentHelper.java
+++ b/generators/montithings2cpp/src/main/java/montithings/generator/helper/ComponentHelper.java
@@ -77,8 +77,6 @@ import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.swing.text.DocumentFilter;
-
 import static montithings.generator.helper.TypesHelper.java2cppTypeString;
 
 /**
@@ -1094,7 +1092,7 @@ public class ComponentHelper {
 
   public static String getInitBehaviorName(ComponentTypeSymbol component, ASTBehavior behavior) {
     return getPortSpecificInitBehaviorName(component,
-      Objects.requireNonNull(getInitBehavior(component, behavior)));
+      Preconditions.checkNotNull(getInitBehavior(component, behavior)));
   }
 
   public static List<ASTInitBehavior> getInitBehaviorsWithoutBehaviors(

--- a/generators/montithings2cpp/src/main/java/montithings/generator/helper/FileHelper.java
+++ b/generators/montithings2cpp/src/main/java/montithings/generator/helper/FileHelper.java
@@ -2,6 +2,7 @@
 package montithings.generator.helper;
 
 import arcbasis._symboltable.ComponentTypeSymbol;
+import com.google.common.base.Verify;
 import de.se_rwth.commons.Names;
 import de.se_rwth.commons.logging.Log;
 import montithings._symboltable.IMontiThingsScope;
@@ -218,7 +219,7 @@ public class FileHelper {
           if (recursive) {
             pathStream = Files.walk(hwcPath.toPath());
           } else {
-            pathStream = Arrays.stream(Objects.requireNonNull(hwcPath.listFiles())).map(File::toPath);
+            pathStream = Arrays.stream(Verify.verifyNotNull(hwcPath.listFiles())).map(File::toPath);
           }
 
           files = pathStream
@@ -251,7 +252,7 @@ public class FileHelper {
           if (recursive) {
             pathStream = Files.walk(hwcPath.toPath());
           } else {
-            pathStream = Arrays.stream(Objects.requireNonNull(hwcPath.listFiles())).map(File::toPath);
+            pathStream = Arrays.stream(Verify.verifyNotNull(hwcPath.listFiles())).map(File::toPath);
           }
 
           files = pathStream
@@ -299,7 +300,7 @@ public class FileHelper {
     File[] subDirs = new File(modelPath).listFiles(File::isDirectory);
 
     // Iterate over subdirectories of the model folder and add the paths of the subdirs to array
-    for (File subDir : Objects.requireNonNull(subDirs)) {
+    for (File subDir : Verify.verifyNotNull(subDirs)) {
       subPackagesPaths.add(new File(subDir.getAbsolutePath()));
     }
 

--- a/generators/montithings2cpp/src/main/java/montithings/generator/steps/generate/GenerateSensorActuatorPorts.java
+++ b/generators/montithings2cpp/src/main/java/montithings/generator/steps/generate/GenerateSensorActuatorPorts.java
@@ -2,6 +2,7 @@
 package montithings.generator.steps.generate;
 
 import arcbasis._symboltable.PortSymbol;
+import com.google.common.base.Verify;
 import de.se_rwth.commons.logging.Log;
 import montithings.generator.config.SplittingMode;
 import montithings.generator.config.TargetPlatform;
@@ -43,7 +44,7 @@ public class GenerateSensorActuatorPorts extends GeneratorStep {
 
     List<String> executableSensorActuatorPorts = new ArrayList<>();
 
-    for (File pckg : Objects.requireNonNull(packages)) {
+    for (File pckg : Verify.verifyNotNull(packages)) {
       Set<String> sensorActuatorPorts = getFilesWithEnding(pckg, getFileEndings(), false);
       for (String port : sensorActuatorPorts) {
         if (!templatePortBelongsToComponent(port, state)) {
@@ -56,7 +57,7 @@ public class GenerateSensorActuatorPorts extends GeneratorStep {
       }
     }
 
-    for (File pckg : Objects.requireNonNull(packages)) {
+    for (File pckg : Verify.verifyNotNull(packages)) {
       Set<String> sensorActuatorPorts = getFilesWithPrefix(pckg, Collections.singleton("&"), false);
       for (String port : sensorActuatorPorts) {
         Log.debug("Processing handwritten port '" + port + "'", TOOL_NAME);


### PR DESCRIPTION
Completed subtasks:
 -  Log::errorIfNull should be deprecated and replaced
 -  Objects::requireNonNull should be replaced as well (technically not part of the Logging issue, but related)

There are still open subtasks in in issue #4835